### PR TITLE
redirect to sykefravaer in person search field and complete app renaming

### DIFF
--- a/build-html.js
+++ b/build-html.js
@@ -38,7 +38,7 @@ fs.readFile(front, (err, data) => {
     if (!fs.existsSync('build/')) {
         fs.mkdirSync('build/');
     }
-    fs.writeFile('build/fastlegefront.html', html, 'utf-8', (writeError) => {
+    fs.writeFile('build/finnfastlege.html', html, 'utf-8', (writeError) => {
         if (writeError) throw writeError;
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "fastlegefront",
+  "name": "finnfastlege",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "fastlegefront",
+    "name": "finnfastlege",
     "version": "0.0.1",
     "description": "Digitalisering av sykefraværsoppfølging",
     "main": "index.js",
@@ -13,8 +13,8 @@
         "test:watch": "cross-env NODE_ENV=test nyc mocha --watch -G --require ignore-styles --compilers js:babel-core/register --require babel-polyfill ./test/setup.js --recursive test",
         "test": "cross-env NODE_ENV=test nyc mocha -G --require ignore-styles --compilers js:babel-core/register --require babel-polyfill ./test/setup.js --recursive test",
         "posttest": "nyc report --reporter=html --reporter=lcov",
-        "static:build:local": "node build-html.js src/app/html/fastlegefront.mustache local",
-        "static:build": "node build-html.js src/app/html/fastlegefront.mustache prod",
+        "static:build:local": "node build-html.js src/app/html/finnfastlege.mustache local",
+        "static:build": "node build-html.js src/app/html/finnfastlege.mustache prod",
         "scripts:build": "set NODE_ENV=production&&node deploy.js",
         "scripts:watch": "webpack-dev-server --inline  --port 3040",
         "lint": "echo skip",

--- a/src/app/html/finnfastlege.mustache
+++ b/src/app/html/finnfastlege.mustache
@@ -20,7 +20,7 @@
 </head>
 <body>
     <div id="header"></div>
-    <div id="maincontent" class="app-fastlegefront side-innhold">
+    <div id="maincontent" class="app-finnfastlege side-innhold">
         <div class="app-spinner blokk-xl" aria-label="Vent litt mens siden laster"></div>
     </div>
 

--- a/src/app/js/index.js
+++ b/src/app/js/index.js
@@ -13,6 +13,7 @@ import tilgang from './reducers/tilgang';
 import egenansatt from './reducers/egenansatt';
 import diskresjonskode from './reducers/diskresjonskode';
 import veilederinfo from './reducers/veilederinfo';
+import { fullAppAdeoUrl } from './utils/miljoUtil';
 import {
     pushModiaContext,
     hentAktivEnhet,
@@ -48,8 +49,8 @@ const handleChangeEnhet = (data) => {
     }
 };
 
-const handlePersonsokSubmit = () => {
-    window.location.href = `/fastlege`;
+const handlePersonsokSubmit = (nyttFnr) => {
+    window.location = fullAppAdeoUrl(`/sykefravaer/${nyttFnr}`);
 };
 
 setEventHandlersOnConfig(handlePersonsokSubmit, handleChangeEnhet);

--- a/src/app/js/utils/miljoUtil.js
+++ b/src/app/js/utils/miljoUtil.js
@@ -1,0 +1,37 @@
+export const erProd = () => {
+    return window.location.href.indexOf('nais.adeo.no') > -1;
+};
+
+export const erPreProd = () => {
+    return window.location.href.indexOf('nais.preprod.local') > -1;
+};
+
+export const erLokal = () => {
+    return window.location.host.indexOf('localhost') > -1;
+};
+
+export const finnNaisUrlDefault = () => {
+    return erPreProd() ?
+        '.nais.preprod.local'
+        : '.nais.adeo.no';
+};
+
+export const finnMiljoStreng = () => {
+    return erPreProd()
+        ? '-q1'
+        : '';
+};
+
+export const fullAppAdeoUrl = (path) => {
+    if (erLokal()) {
+        return path;
+    }
+    return `https://app${finnMiljoStreng()}.adeo.no${path}`;
+};
+
+export const fullNaisUrlDefault = (host, path) => {
+    if (erLokal()) {
+        return path;
+    }
+    return `https://${host}${finnNaisUrlDefault()}${path}`;
+};

--- a/src/server.js
+++ b/src/server.js
@@ -49,7 +49,7 @@ const setupRoutes = () => {
         '/fastlege/*',
         (req, res) => {
             res.sendFile(
-                path.join(__dirname, '..', 'build', 'fastlegefront.html'),
+                path.join(__dirname, '..', 'build', 'finnfastlege.html'),
                 {},
             );
         },


### PR DESCRIPTION
Redirect to sykefravaer when searching for a person in internarbeidsflatedecorator, and completing the renaming of the application from fastlegefront to finnfastlege