### PR TITLE
Simplify debugging of components using Styled-components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
     "@babel/preset-typescript"
   ],
   "plugins": [
+    "babel-plugin-styled-components",
     "@babel/plugin-transform-regenerator",
     "@babel/transform-runtime",
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "axios-mock-adapter": "1.20.0",
         "babel-loader": "8.2.4",
         "babel-plugin-module-resolver": "4.1.0",
+        "babel-plugin-styled-components": "^2.0.7",
         "chai": "4.3.6",
         "clean-webpack-plugin": "4.0.0",
         "css-loader": "6.7.1",
@@ -3710,9 +3711,9 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz",
-      "integrity": "sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
@@ -14877,9 +14878,9 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz",
-      "integrity": "sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "axios-mock-adapter": "1.20.0",
     "babel-loader": "8.2.4",
     "babel-plugin-module-resolver": "4.1.0",
+    "babel-plugin-styled-components": "2.0.7",
     "chai": "4.3.6",
     "clean-webpack-plugin": "4.0.0",
     "css-loader": "6.7.1",


### PR DESCRIPTION
Add babel-plugin-styled-components to make is easier to debug html elements and css rendered from componennts using styled-components. This package adds automatic annoations of styled components with a unique and readable html class name.