### PR TITLE
Use redis password

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -25,6 +25,7 @@ spec:
     timeout: 5
   envFrom:
     - secret: finnfastlege-session-key
+    - secret: finnfastlege-redis-password
   env:
     - name: NODE_ENV
       value: production

--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -55,7 +55,6 @@ spec:
       value: "http://syfo-tilgangskontroll"
   resources:
     limits:
-      cpu: 500m
       memory: 256Mi
     requests:
       cpu: 100m

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -25,6 +25,7 @@ spec:
     timeout: 5
   envFrom:
     - secret: finnfastlege-session-key
+    - secret: finnfastlege-redis-password
   env:
     - name: NODE_ENV
       value: production

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -55,7 +55,6 @@ spec:
       value: "http://syfo-tilgangskontroll"
   resources:
     limits:
-      cpu: 500m
       memory: 256Mi
     requests:
       cpu: 100m

--- a/.nais/redis/redis-config.yaml
+++ b/.nais/redis/redis-config.yaml
@@ -15,6 +15,8 @@ spec:
     min: 1
     max: 1
   resources:
+    limits:
+      memory: 100Mi
     requests:
       cpu: 100m
       memory: 128Mi

--- a/.nais/redis/redis-config.yaml
+++ b/.nais/redis/redis-config.yaml
@@ -9,15 +9,12 @@ metadata:
   namespace: teamsykefravr
   name: finnfastlege-redis
 spec:
-  image: redis:5-alpine
+  image: bitnami/redis:6.0.12
   port: 6379
   replicas:
     min: 1
     max: 1
   resources:
-    limits:
-      cpu: 100m
-      memory: 128Mi
     requests:
       cpu: 100m
       memory: 128Mi
@@ -29,3 +26,5 @@ spec:
       rules:
         - application: finnfastlege
         - application: finnfastlege-redisexporter
+  envFrom:
+    - secret: finnfastlege-redis-password

--- a/.nais/redis/redisexporter.yaml
+++ b/.nais/redis/redisexporter.yaml
@@ -14,6 +14,8 @@ spec:
     min: 1
     max: 1
   resources:
+    limits:
+      memory: 100Mi
     requests:
       cpu: 100m
       memory: 100Mi

--- a/.nais/redis/redisexporter.yaml
+++ b/.nais/redis/redisexporter.yaml
@@ -14,9 +14,6 @@ spec:
     min: 1
     max: 1
   resources:
-    limits:
-      cpu: 100m
-      memory: 100Mi
     requests:
       cpu: 100m
       memory: 100Mi
@@ -31,3 +28,5 @@ spec:
       value: finnfastlege-redis:6379
     - name: REDIS_EXPORTER_LOG_FORMAT
       value: json
+  envFrom:
+    - secret: finnfastlege-redis-password


### PR DESCRIPTION
Det mangler redis-password i frontend-app'ene. Forsøker å få til samme redis-konfig som i backend-app'ene.

Har opprettet secret finnfastlege-redis-password i hhv dev-gcp og prod-gcp 