### PR TITLE
Use wonderwall

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -71,6 +71,9 @@ spec:
         - application: syfoperson
         - application: finnfastlege-redis
   azure:
+    sidecar:
+      enabled: true
+      autoLogin: true
     application:
       allowAllUsers: true
       enabled: true

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -71,6 +71,9 @@ spec:
         - application: syfoperson
         - application: finnfastlege-redis
   azure:
+    sidecar:
+      enabled: true
+      autoLogin: true
     application:
       allowAllUsers: true
       enabled: true

--- a/server.ts
+++ b/server.ts
@@ -28,6 +28,18 @@ const setupServer = async () => {
     next();
   };
 
+  const redirectIfUnauthorized = async (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+  ) => {
+    if (req.headers["authorization"]) {
+      next();
+    } else {
+      res.redirect(`/oauth2/login?redirect=${req.originalUrl}`);
+    }
+  };
+
   const DIST_DIR = path.join(__dirname, "dist");
   const HTML_FILE = path.join(DIST_DIR, "index.html");
 
@@ -44,8 +56,8 @@ const setupServer = async () => {
 
   server.get(
     ["/", "/fastlege", "/fastlege/*", /^\/fastlege\/(?!(resources|img)).*$/],
-    nocache,
-    (req, res) => {
+    [nocache, redirectIfUnauthorized],
+    (req: express.Request, res: express.Response) => {
       res.sendFile(HTML_FILE);
     }
   );

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -33,7 +33,7 @@ function handleAxiosError(error: AxiosError) {
   if (error.response) {
     switch (error.response.status) {
       case 401: {
-        window.location.href = `/login?redirectTo=${window.location.pathname}`;
+        window.location.href = `/oauth2/login?redirectTo=${window.location.pathname}`;
         throw new ApiErrorException(
           loginRequiredError(error.message),
           error.response.status


### PR DESCRIPTION
Ser ut som denne minimale løsningen kan fungere, men bare et draft foreløpig. 

Jeg er usikker på hvor godt samspillet med den eksisterende koden i server/auth-pakken blir. I tillegg til dette tror jeg vi har noen mangler i forhold til token-validering, så det bør også forbedres. 

Det er ikke så enkelt å rive ut den eksisterende koden som bruker OpenIdClient og passport: 
1. Vi fortsatt må gjøre kall til OpenIdClient for å hente obo-tokens, tror ikke wonderwall hjelper oss noe på den fronten.
2. Både user og tokenset caches nå i redis knyttet til et session-objekt, og disse objektene henger på request'en - dette er avhengig av kode i passport-avhengigheten.