### PR TITLE
verify accessToken always

### DIFF
--- a/server/authUtils.ts
+++ b/server/authUtils.ts
@@ -48,10 +48,8 @@ const retrieveToken = async (
   req: Request,
   azureAdIssuer: OpenIdClient.Issuer<any>
 ): Promise<string | undefined> => {
-  const start = Date.now();
   const token = req.headers.authorization?.replace("Bearer ", "");
   if (token && (await validateToken(token, azureAdIssuer))) {
-    console.log("token validated: " + (Date.now() - start) + " ms");
     return token;
   }
   return undefined;

--- a/server/authUtils.ts
+++ b/server/authUtils.ts
@@ -44,12 +44,20 @@ export const ensureAuthenticated = () => {
   };
 };
 
+function getNanoSecTime() {
+  var hrTime = process.hrtime();
+  return hrTime[0] * 1000000000 + hrTime[1];
+}
+
 const retrieveToken = async (
   req: Request,
   azureAdIssuer: OpenIdClient.Issuer<any>
 ): Promise<string | undefined> => {
+  const start = getNanoSecTime();
   const token = req.headers.authorization?.replace("Bearer ", "");
   if (token && (await validateToken(token, azureAdIssuer))) {
+    const end = getNanoSecTime();
+    console.log("token validated: " + (end - start) + " ns");
     return token;
   }
   return undefined;

--- a/server/authUtils.ts
+++ b/server/authUtils.ts
@@ -44,20 +44,14 @@ export const ensureAuthenticated = () => {
   };
 };
 
-function getNanoSecTime() {
-  var hrTime = process.hrtime();
-  return hrTime[0] * 1000000000 + hrTime[1];
-}
-
 const retrieveToken = async (
   req: Request,
   azureAdIssuer: OpenIdClient.Issuer<any>
 ): Promise<string | undefined> => {
-  const start = getNanoSecTime();
+  const start = Date.now();
   const token = req.headers.authorization?.replace("Bearer ", "");
   if (token && (await validateToken(token, azureAdIssuer))) {
-    const end = getNanoSecTime();
-    console.log("token validated: " + (end - start) + " ns");
+    console.log("token validated: " + (Date.now() - start) + " ms");
     return token;
   }
   return undefined;


### PR DESCRIPTION
Tror det er best å alltid verifisere token (også når vi egentlig ikke trenger det for å hente et obo-token).