### PR TITLE
Use nodejs18-debian12 base-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as builder
+FROM node:18-alpine AS builder
 WORKDIR /finnfastlege
 
 COPY server.ts package.json tsconfig.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY dist ./dist
 RUN npm install -g typescript
 RUN tsc --build
 
-FROM gcr.io/distroless/nodejs18-debian11
+FROM gcr.io/distroless/nodejs18-debian12
 WORKDIR /finnfastlege
 
 COPY --from=builder /finnfastlege/package.json ./


### PR DESCRIPTION
Virker ikke som om debian11-varianten vedlikeholdes lengre siden det er noen criticals som ikke blir borte. Tipper det funker bedre med debian12. Fikser de tre andre frontend'ene hvis vi ikke oppdager noe problematisk i finnfastlege.