### PR TITLE
Use the users enhet from context & avoid resetting

### DIFF
--- a/src/decorator/decoratorProps.ts
+++ b/src/decorator/decoratorProps.ts
@@ -18,8 +18,8 @@ export interface DecoratorProps {
   environment: Environment; // Miljø som skal brukes.
   urlFormat: UrlFormat; // URL format
   proxy?: string | undefined; // Manuell overstyring av urlene til BFFs. Gjør alle kall til relativt path hvis true, og bruker verdien som domene om satt til en string. Default: false
-  fnrSyncMode: "sync" | "writeOnly"; // Modus til fnr state management. "sync" er default. "writeOnly" gjør at endringer aldri hentes men vil settes dersom det oppdateres lokalt i appen
-  enhetSyncMode?: "sync" | "writeOnly"; // Samme som fnrSyncMode, men for enhet state.
+  fnrSyncMode: "sync" | "writeOnly" | "ignore"; // Modus til fnr state management. "sync" er default. "writeOnly" gjør at endringer aldri hentes men vil settes dersom det oppdateres lokalt i appen
+  enhetSyncMode?: "sync" | "writeOnly" | "ignore"; // Samme som fnrSyncMode, men for enhet state.
 }
 
 export interface Markup {

--- a/src/decorator/decoratorconfig.ts
+++ b/src/decorator/decoratorconfig.ts
@@ -4,7 +4,6 @@ import { erAnsattDev, erDev, erLokal, erProd } from "@/utils/miljoUtil";
 const decoratorConfig = (setFnr: (fnr: string) => void): DecoratorProps => {
   return {
     appName: "Sykefraværsoppfølging",
-    fetchActiveEnhetOnMount: false,
     onEnhetChanged: () => {
       // do nothing
     },
@@ -13,14 +12,14 @@ const decoratorConfig = (setFnr: (fnr: string) => void): DecoratorProps => {
         setFnr(fnr);
       }
     },
-    showEnheter: true,
+    showEnheter: false,
     showSearchArea: true,
     showHotkeys: false,
     environment: getEnvironment(),
     urlFormat: getUrlFormat(),
     proxy: "/modiacontextholder",
     fnrSyncMode: "writeOnly",
-    enhetSyncMode: "writeOnly",
+    enhetSyncMode: "ignore",
   };
 };
 


### PR DESCRIPTION
When `enhetSyncMode` is `"writeOnly"` the app is responsible for setting
the users enhet in context. In this case, the enhet is never set, so the
app resets the enhet every time it is loaded. We ignore it as the app
does not use the enhet.
