### PR TITLE
Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs22-debian13
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:22-slim
 WORKDIR /finnfastlege
 
 COPY package.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs22-debian12
+FROM gcr.io/distroless/nodejs22-debian13
 WORKDIR /finnfastlege
 
 COPY package.json ./


### PR DESCRIPTION
Alle app'ene våre både (frontend og backend) trenger denne oppdateringen. Debian12-variantene kommer ikke i nye versjoner lengre, så base-image'ne som vi bruker nå er fra begynnelsen av mars.

Egentlig en bra anledning til å gå over til chainguard: https://sikkerhet.nav.no/docs/verktoy/chainguard-dockerimages/