### PR TITLE
IS-3877: CommonJS to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "finnfastlege",
   "version": "0.0.1",
   "description": "Digitalisering av sykefraværsoppfølging",
+  "type": "module",
   "main": "index.tsx",
   "test": "pnpm test",
   "scripts": {
@@ -9,8 +10,8 @@
     "lint-and-typecheck": "pnpm lint && pnpm typecheck",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint src test --ext .ts  --ext .tsx  --ext .js  --ext .jsx",
-    "start": "webpack serve --config webpack.dev.ts",
-    "build": "webpack --config webpack.prod.ts && pnpm run build:server",
+    "start": "webpack serve --config webpack.dev.js",
+    "build": "webpack --config webpack.prod.js && pnpm run build:server",
     "build:server": "tsc --build ./server/tsconfig.json"
   },
   "author": "Team DigiSyfo <digisyfo@nav.no>",
@@ -112,6 +113,9 @@
     "overrides": {
       "@webpack-cli/serve": "1.6.1",
       "lodash": "4.18.1"
+    },
+    "patchedDependencies": {
+      "openid-client@4.2.2": "patches/openid-client@4.2.2.patch"
     }
   }
 }

--- a/patches/openid-client@4.2.2.patch
+++ b/patches/openid-client@4.2.2.patch
@@ -1,0 +1,20 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index 8a9370241f3f43fbc3101555275be6b22f7b0107..0000000000000000000000000000000000000000
+diff --git a/package.json b/package.json
+index 5e7d0dd5091d7463ee0acfa09ad68b2164032954..6ed4517aeb012cfae167ddc1da7784a90994aa06 100644
+--- a/package.json
++++ b/package.json
+@@ -130,5 +130,12 @@
+         "hidden": true
+       }
+     ]
++  },
++  "exports": {
++    ".": {
++      "types": "./types/index.d.ts",
++      "import": "./lib/index.mjs",
++      "require": "./lib/index.js"
++    }
+   }
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,11 @@ overrides:
   '@webpack-cli/serve': 1.6.1
   lodash: 4.18.1
 
+patchedDependencies:
+  openid-client@4.2.2:
+    hash: c43ac6402b1d1827dcc01ca6bf90b12a3002f6975513d8d5ca562ee753eddf2f
+    path: patches/openid-client@4.2.2.patch
+
 importers:
 
   .:
@@ -101,7 +106,7 @@ importers:
         version: 6.1.1
       openid-client:
         specifier: 4.2.2
-        version: 4.2.2
+        version: 4.2.2(patch_hash=c43ac6402b1d1827dcc01ca6bf90b12a3002f6975513d8d5ca562ee753eddf2f)
       prom-client:
         specifier: 14.0.1
         version: 14.0.1
@@ -9211,7 +9216,7 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openid-client@4.2.2:
+  openid-client@4.2.2(patch_hash=c43ac6402b1d1827dcc01ca6bf90b12a3002f6975513d8d5ca562ee753eddf2f):
     dependencies:
       base64url: 3.0.1
       got: 11.8.6

--- a/server.ts
+++ b/server.ts
@@ -1,11 +1,13 @@
 import express, { RequestHandler } from "express";
 import path from "path";
 import prometheus from "prom-client";
+import { getOpenIdClient, getOpenIdIssuer } from "./server/authUtils.js";
+import { setupProxy } from "./server/proxy.js";
+import { setupSession } from "./server/session.js";
+import { fileURLToPath } from "url";
 
-import * as Config from "./server/config";
-import { getOpenIdClient, getOpenIdIssuer } from "./server/authUtils";
-import { setupProxy } from "./server/proxy";
-import { setupSession } from "./server/session";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Prometheus metrics
 const collectDefaultMetrics = prometheus.collectDefaultMetrics;

--- a/server/authUtils.ts
+++ b/server/authUtils.ts
@@ -1,14 +1,15 @@
-import OpenIdClient from "openid-client";
+import { Client, Issuer } from "openid-client";
 import { Request } from "express";
 import {
   createRemoteJWKSet,
   FlattenedJWSInput,
+  GetKeyFunction,
   JWSHeaderParameters,
+  JWTPayload,
   jwtVerify,
 } from "jose";
-import { GetKeyFunction, JWTPayload } from "jose/dist/types/types";
 
-import * as Config from "./config";
+import * as Config from "./config.js";
 
 type OboToken = {
   accessToken: string;
@@ -36,7 +37,7 @@ async function initJWKSet() {
 
 const retrieveAndValidateToken = async (
   req: Request,
-  azureAdIssuer: OpenIdClient.Issuer<any>
+  azureAdIssuer: Issuer<any>
 ): Promise<string | undefined> => {
   const token = req.headers.authorization?.replace("Bearer ", "");
   if (token && (await validateToken(token, azureAdIssuer))) {
@@ -45,10 +46,7 @@ const retrieveAndValidateToken = async (
   return undefined;
 };
 
-const validateToken = async (
-  token: string,
-  azureAdIssuer: OpenIdClient.Issuer<any>
-) => {
+const validateToken = async (token: string, azureAdIssuer: Issuer<any>) => {
   try {
     if (!_remoteJWKSet) {
       await initJWKSet();
@@ -90,8 +88,8 @@ const isNotExpired = (token: CachedOboToken) => {
 };
 
 export const getOrRefreshOnBehalfOfToken = async (
-  authClient: OpenIdClient.Client,
-  issuer: OpenIdClient.Issuer<any>,
+  authClient: Client,
+  issuer: Issuer<any>,
   req: Request,
   clientId: string
 ): Promise<OboToken | undefined> => {
@@ -127,7 +125,7 @@ export const getOrRefreshOnBehalfOfToken = async (
 };
 
 const requestOnBehalfOfToken = async (
-  authClient: OpenIdClient.Client,
+  authClient: Client,
   accessToken: string,
   clientId: string
 ): Promise<OboToken | undefined> => {
@@ -150,18 +148,16 @@ const requestOnBehalfOfToken = async (
   }
 };
 
-export const getOpenIdIssuer = async (): Promise<OpenIdClient.Issuer<any>> => {
+export const getOpenIdIssuer = async (): Promise<Issuer<any>> => {
   try {
-    return OpenIdClient.Issuer.discover(Config.auth.discoverUrl);
+    return Issuer.discover(Config.auth.discoverUrl);
   } catch (e) {
     console.log("Could not discover issuer", Config.auth.discoverUrl);
     throw e;
   }
 };
 
-export const getOpenIdClient = async (
-  issuer: OpenIdClient.Issuer<any>
-): Promise<OpenIdClient.Client> => {
+export const getOpenIdClient = async (issuer: Issuer<any>): Promise<Client> => {
   return new issuer.Client(
     {
       client_id: Config.auth.clientId,

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -1,10 +1,10 @@
 import express from "express";
 import expressHttpProxy from "express-http-proxy";
 import url from "url";
-import OpenIdClient from "openid-client";
+import { Client, Issuer } from "openid-client";
 
-import { getOrRefreshOnBehalfOfToken } from "./authUtils";
-import * as Config from "./config";
+import { getOrRefreshOnBehalfOfToken } from "./authUtils.js";
+import * as Config from "./config.js";
 
 const proxyExternalHost = (
   { applicationName, host, removePathPrefix }: any,
@@ -61,8 +61,8 @@ const proxyOnBehalfOf = (
   req: express.Request,
   res: express.Response,
   next: express.NextFunction,
-  authClient: OpenIdClient.Client,
-  issuer: OpenIdClient.Issuer<any>,
+  authClient: Client,
+  issuer: Issuer<any>,
   externalAppConfig: Config.ExternalAppConfig
 ) => {
   getOrRefreshOnBehalfOfToken(
@@ -94,8 +94,8 @@ const proxyOnBehalfOf = (
 };
 
 export const setupProxy = (
-  authClient: OpenIdClient.Client,
-  issuer: OpenIdClient.Issuer<any>
+  authClient: Client,
+  issuer: Issuer<any>
 ): express.Router => {
   const router = express.Router();
 

--- a/server/session.ts
+++ b/server/session.ts
@@ -3,7 +3,7 @@ import connectRedis from "connect-redis";
 import session from "express-session";
 import redis from "redis";
 
-import * as Config from "./config";
+import * as Config from "./config.js";
 
 const SESSION_MAX_AGE_SECONDS = 12 * 60 * 60;
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "rootDir": "..",
     "outDir": "../dist-server",
     "composite": true,
-    "tsBuildInfoFile": "../dist-server/.tsbuildinfo"
+    "tsBuildInfoFile": "../dist-server/.tsbuildinfo",
+    "noEmit": false,
+    "allowImportingTsExtensions": false
   },
   "include": ["../server.ts", "./**/*.ts"],
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,18 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ESNext",
     "target": "ES2019",
     "lib": ["es2019", "dom"],
     "sourceMap": true,
     "allowJs": true,
     "jsx": "react",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "outDir": "./dist",
     "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "strict": true,
     "noImplicitAny": true,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,15 +1,16 @@
-import "regenerator-runtime/runtime";
-
 import path from "path";
-import { Configuration } from "webpack";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import Dotenv from "dotenv-webpack";
 import autoprefixer from "autoprefixer";
+import { fileURLToPath } from "url";
 
 const extensions = [".tsx", ".jsx", ".js", ".ts", ".json"];
 
-const commonConfig: Configuration = {
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const commonConfig = {
   entry: {
     main: ["./src/index.tsx"],
   },

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,9 +1,7 @@
 import { merge } from "webpack-merge";
-import * as Webpack from "webpack";
+import common from "./webpack.common.js";
 
-import common from "./webpack.common";
-
-const devConfig: Webpack.Configuration = {
+const devConfig = {
   mode: "development",
   devtool: "eval-source-map",
   output: {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,8 @@
+import { merge } from "webpack-merge";
+import common from "./webpack.common.js";
+
+const productionConfig = {
+  mode: "production",
+};
+
+export default merge(common, productionConfig);

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -1,9 +1,0 @@
-import { merge } from "webpack-merge";
-import common from "./webpack.common";
-import { Configuration as WebpackConfiguration } from "webpack";
-
-const productionConfig: WebpackConfiguration = {
-  mode: "production",
-};
-
-export default merge(common, productionConfig);


### PR DESCRIPTION
Bytter over til ESM tilsvarende [denne PRen](https://github.com/navikt/syfomodiaperson/pull/2024)

Tidligere har appen brukt TS-typer som egentlig ikke har blitt eksportert fra `openid-client` (men TS har godtatt det). ESM er strengere, og appen ville derfor ikke bygge. Jeg ville unngå å oppgradere dependencien siden den uansett [skal fjernes](https://trello.com/c/OcPvNZwr), og fikk derfor Copilot til å generere en PNPM patch av pakken slik at de påkrevde typene faktisk kan importeres. Dette fjernes når man innfører bruk av Texas :cowboy_hat_face: 

[x] Testet i dev