### PR TITLE
Update @navikt/navspa package to 7.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@navikt/ds-css": "7.33.2",
     "@navikt/ds-react": "7.33.2",
     "@navikt/fnrvalidator": "1.3.0",
-    "@navikt/navspa": "7.4.0",
+    "@navikt/navspa": "7.5.0",
     "@tanstack/react-query": "5.90.7",
     "@tanstack/react-query-devtools": "5.90.2",
     "@types/express": "4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 1.3.0
         version: 1.3.0
       '@navikt/navspa':
-        specifier: 7.4.0
-        version: 7.4.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: 7.5.0
+        version: 7.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query':
         specifier: 5.90.7
         version: 5.90.7(react@19.2.1)
@@ -1279,8 +1279,8 @@ packages:
   '@navikt/fnrvalidator@1.3.0':
     resolution: {integrity: sha512-k1MEZ8xwxtmY570gB+BF38kr9Xta1KIcx0yUExHQZWIsD1PNGSVagoriRTxqGyyTTkt4ajk1Z18WPfWX7rtpgQ==, tarball: https://npm.pkg.github.com/download/@navikt/fnrvalidator/1.3.0/8cea6bae592f772d07efebe9a5ab7179552e1d6f}
 
-  '@navikt/navspa@7.4.0':
-    resolution: {integrity: sha512-WQCyOnbBHJRxtp6Hq1CMmHFW83z0zuJ2HNBajhHtVhcnR5dV01GfxMFX1clqNsigByrU9yTaxEbFNLacoSgLSA==, tarball: https://npm.pkg.github.com/download/@navikt/navspa/7.4.0/8e7cfa5ca022fa7301e85796f39de4374eaf47ac}
+  '@navikt/navspa@7.5.0':
+    resolution: {integrity: sha512-md8EDCzOpv5aHdDYHxW23fxQCFghHklli+AyfSBkGZ5gGKApi4LatDYUoJuTlnTZihMI89FX80sFC79ms/QewA==, tarball: https://npm.pkg.github.com/download/@navikt/navspa/7.5.0/d82d23977eec915b4a7bcd7d287d53074632462e}
     peerDependencies:
       react: '>=19.2.1'
       react-dom: '>=19.2.1'
@@ -6063,7 +6063,7 @@ snapshots:
 
   '@navikt/fnrvalidator@1.3.0': {}
 
-  '@navikt/navspa@7.4.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@navikt/navspa@7.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       loadjs: 4.3.0
       react: 19.2.1


### PR DESCRIPTION
Ref. [denne PRen](https://github.com/navikt/navspa/pull/90), så kan vi nå ved en oppgradering av `@navikt/navspa` nå oppgradere minorversjoner av React fritt. Dette gjør at Dependabot-PRer som [denne](https://github.com/navikt/finnfastlege/pull/328) trolig vil ha mye større sjanse for å bygge grønt fremover. Mulig de PRene Dependabot allerede har laget må rebases.

Jeg har testet dette i dev.