### PR TITLE
setup for dependabot auto merge

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: daily
       time: "07:00"
+      timezone: "Europe/Oslo"
+      days:
+        - monday
+        - tuesday
+        - wednesday
+        - thursday
+        - friday
     cooldown:
       default-days: 3
     open-pull-requests-limit: 10
@@ -13,6 +20,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+      time: "07:00"
+      timezone: "Europe/Oslo"
     cooldown:
       default-days: 3
     open-pull-requests-limit: 10

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,15 +3,10 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
       time: "09:00"
       timezone: "Europe/Oslo"
-      days:
-        - monday
-        - tuesday
-        - wednesday
-        - thursday
-        - friday
     cooldown:
       default-days: 3
     open-pull-requests-limit: 10
@@ -20,6 +15,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+      day: monday
       time: "09:00"
       timezone: "Europe/Oslo"
     cooldown:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "07:00"
+      time: "09:00"
       timezone: "Europe/Oslo"
       days:
         - monday
@@ -20,7 +20,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-      time: "07:00"
+      time: "09:00"
       timezone: "Europe/Oslo"
     cooldown:
       default-days: 3

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,8 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-      day: tuesday
-      time: "09:00"
+      day: monday
+      time: "07:00"
       timezone: "Europe/Oslo"
     cooldown:
       default-days: 3

--- a/.github/workflows/dependabot-auto-merge.yaml.yml
+++ b/.github/workflows/dependabot-auto-merge.yaml.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Check freeze window
+        id: freeze-check
+        run: |
+          MONTH_DAY=$(TZ="Europe/Oslo" date +%m%d)
+          if [[ "$MONTH_DAY" -ge 1220 || "$MONTH_DAY" -le 0102 || ( "$MONTH_DAY" -ge 0710 && "$MONTH_DAY" -le 0810 ) ]]; then
+            echo "frozen=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Dependabot metadata
+        if: steps.freeze-check.outputs.frozen == 'false'
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Auto-merge changes from Dependabot
+        if: steps.freeze-check.outputs.frozen == 'false' && (steps.metadata.outputs.update-type != 'version-update:semver-major' || steps.metadata.outputs.package-ecosystem == 'github_actions')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-ignore-scripts=true
 registry=https://registry.npmjs.org/
 @navikt:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ settings.json
 .vscode/
 *.yaml
 *.yml
+mockServiceWorker.js

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "author": "Team DigiSyfo <digisyfo@nav.no>",
   "license": "ISC",
-  "packageManager": "pnpm@11.0.0",
+  "packageManager": "pnpm@11.1.2",
   "dependencies": {
     "@grafana/faro-react": "1.19.0",
     "@grafana/faro-web-sdk": "1.19.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "author": "Team DigiSyfo <digisyfo@nav.no>",
   "license": "ISC",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.0",
   "dependencies": {
     "@grafana/faro-react": "1.19.0",
     "@grafana/faro-web-sdk": "1.19.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ allowBuilds:
   msw: true
   protobufjs: true
   styled-components: true
+  ignoreScripts: true


### PR DESCRIPTION
Har lyst til å teste ut en litt forenklet fremgangsmåte som forhåpentig gjør at vi slipper å introdusere merge queue, siden vi har konfigurert dependabot til å samle minor/patch oppdateringer i en PR, en gang i uken.

Workflow er hentet herfra https://doc.nais.io/build/how-to/dependabot-auto-merge/
Den markerer alle PR'r opprettet av dependabot til å kunne automerges hvis det er minor/patch oppdatering.
Automerge blir kun gjennomført hvis hvis bygg/test går igjennom. Merging skjer med andre ord rett etter opprettelse.
