### PR TITLE
Fix broken mocks

### DIFF
--- a/src/mocks/mockIstilgangskontroll.ts
+++ b/src/mocks/mockIstilgangskontroll.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from "msw";
 
 const mockIstilgangskontroll = http.get(
-  "/istilgangskontroll/api/tilgang/navident/syfo",
+  "/istilgangskontroll/api/tilgang/navident/finnfastlege",
   () => {
     return HttpResponse.json({
       erGodkjent: true,

--- a/src/mocks/mockModiacontextholder.ts
+++ b/src/mocks/mockModiacontextholder.ts
@@ -36,7 +36,7 @@ const mockModiacontextholder = [
     return HttpResponse.json(aktivBruker);
   }),
 
-  http.get("/modiacontextholder/api/context/aktivenhet", () => {
+  http.get("/modiacontextholder/api/context/v2/aktivenhet", () => {
     return HttpResponse.json(aktivEnhet);
   }),
 


### PR DESCRIPTION
Fikser et par mocks som brekker Finnfastlege lokalt. Den ene URL-pathen ble endret i sommer og mocken glemt, mens den andre fra dekoratøren sikkert har sklidd over til en v2 en eller annen gang de siste ukene.